### PR TITLE
One docker compose mode and light supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ DEFAULT_SERVICE_ROLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJyb2xlIjo
 
 # Start
 
+## Launch All services
+
+### start docker container
+```
+cd web
+docker compose up     
+```
+### go to: `http://localhost:5173/`
 ## Supabase
 
 Supabase default credentials with this project are:
@@ -45,35 +53,14 @@ Supabase default credentials with this project are:
 login: supabase
 pass: supabase123
 ```
-### On first launch
-```
-cd /{PROJECT_PATH}/supabase/docker
-docker-compose up --force-recreate
-```
-
-Copy and execute sql from
-`web/app/database_migration.sql` into `http://localhost:8000/project/default/sql/1`
-
-### Subsequent laucnh
-> docker compose up
 
 go to `url: http://localhost:8000/`
 
 
-## Launch web
-
-### start docker container
-```
-cd web
-docker compose up     # Just launch the container without running nodejs
-```
-### Connect to web container and launch web server
+### Connect to web container 
 ```
 docker exec -it {containerID} /bin/bash
-pnpm run dev
 ```
-
-### go to: `http://localhost:5173/`
 
 # Further details
 go to:

--- a/web/docker-compose.yml
+++ b/web/docker-compose.yml
@@ -1,14 +1,16 @@
-version: "3"
+include:
+  - path : ../supabase/docker/docker-compose.yml  #with serviceB declared
+    env_file: ../supabase/docker/.env
 
 services:
   web:
     container_name: ${APP_NAME}
-    image: ${APP_NAME}/web
     build: 
       context: .
       dockerfile: docker/Dockerfile
-    restart: unless-stopped
+    # restart: unless-stopped
     # restart: no
+    command: pnpm run dev --host 0.0.0.0 --port ${HTTP_APP_PORT}
     env_file:
       - .env
     environment:
@@ -16,13 +18,18 @@ services:
       HTTP_APP_PORT: ${HTTP_APP_PORT:-5173}
       APP_PATH: ${APP_PATH:-/var/www/app/}
     ports:
-      - 5173:${HTTP_APP_PORT}
+      - ${HTTP_APP_PORT}:${HTTP_APP_PORT}
       # - ${HTTPS_APP_PORT}:8443
     volumes:
-      - ./app/:${APP_PATH}
-      - /var/www/app/node_modules
+      - ./app/:${APP_PATH:-/var/www/app/}
+      - ${APP_PATH:-/var/www/app/}/node_modules
 
-networks:
-  default:
-    name: ${NETWORK_NAME}
-    external: true # network must have been created by another container
+  adminer:
+    image: adminer
+    #restart: always
+    ports:
+      - ${ADMINER_HOST_PORT:-8080}:8080
+# networks:
+#   default:
+#     name: ${NETWORK_NAME}
+#     external: true # network must have been created by another container

--- a/web/docker/Dockerfile
+++ b/web/docker/Dockerfile
@@ -44,5 +44,4 @@ EXPOSE ${HTTP_APP_PORT}
 WORKDIR ${APP_PATH}
 RUN pnpm install
 
-ENTRYPOINT ["tail", "-f", "/dev/null"]
-# ENTRYPOINT ["pnpm", "run", "dev"]
+# ENTRYPOINT ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
Juste use docker compose in web directory
no need to run the vite dev server manually  - if restart is needed juste do `docker compose restart web`
fetch only supaabase docker directory to speed up installation 

TODO :

add depend on between web and supabase
run minimal configuration for supaabase ( eg exclude analytics )